### PR TITLE
build: update package version and Svelte peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "progressbar-svelte",
-  "version": "0.0.8",
+  "version": "1.0.0",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run package",
@@ -22,7 +22,7 @@
     "!dist/**/*.spec.*"
   ],
   "peerDependencies": {
-    "svelte": "^4.0.0"
+    "svelte": "^5.0.0"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.0.0",
@@ -30,7 +30,7 @@
     "@sveltejs/package": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "publint": "^0.1.9",
-    "svelte": "^4.2.7",
+    "svelte": "^5.0.0",
     "svelte-check": "^3.6.0",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",


### PR DESCRIPTION
Bump package version to 1.0.0 and update Svelte peer dependency to ^5.0.0 to align with the latest major release of Svelte